### PR TITLE
Fix al contador de invoices

### DIFF
--- a/app/Company.php
+++ b/app/Company.php
@@ -300,23 +300,14 @@ class Company extends Model {
     
     public function addSentInvoice($year, $month) {
         try {
-            if(!$month || !$year) {
-                $today = Carbon::parse(now('America/Costa_Rica'));
-                $month = $today->month;
-                $year = $today->year;
-            }
-             
-            $available_invoices = AvailableInvoices::where('company_id', $this->id)
-                                ->where('month', $month)
-                                ->where('year', $year)
-                                ->first();
+            $available_invoices = $this->getAvailableInvoices(0,0);
 
             $available_invoices->current_month_sent = $available_invoices->current_month_sent + 1;
             $available_invoices->save();
             return $available_invoices;
 
         } catch (\Throwable $ex) {
-             Log::warning('Error en addSentInvoice: ' . $ex->getMessage() );
+             Log::error('Error en addSentInvoice: ' . $ex->getMessage() );
         }
     }
     


### PR DESCRIPTION
En el contador de invoices revisaba los availables invoices pero siempre asumia que tenia el row creado para el mes. Ahora llama al metodo getAvailableInvoices que si no encuentra lo crea.